### PR TITLE
fix - ts typings now export slugify correctly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,4 +9,4 @@ declare function slugify(
     | string,
 ): string;
 
-export = slugify;
+export default slugify;


### PR DESCRIPTION
This fixes the problem with Webpack + TS-Loader not working correctly after slugify added TS definitions.