### PR TITLE
Support TypeScript types for `extend` properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,12 @@
-declare function slugify(
+module slugify {
+  type ExtendArgs = {
+    [key: string]: any;
+  }
+
+  export function extend (args: ExtendArgs): void;
+}
+
+function slugify(
   string: string,
   options?:
     | {
@@ -7,6 +15,7 @@ declare function slugify(
         lower?: boolean;
       }
     | string,
+
 ): string;
 
 export default slugify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-module slugify {
+declare module slugify {
   type ExtendArgs = {
     [key: string]: any;
   }
@@ -6,7 +6,7 @@ module slugify {
   export function extend (args: ExtendArgs): void;
 }
 
-function slugify(
+declare function slugify(
   string: string,
   options?:
     | {


### PR DESCRIPTION
Fix #26 