### PR TITLE
Update eslint and related packages; fix new linting errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - 10
   - 8
   - 6
-  - 4
 
 after_script:
   - npm run test:cov

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@
     }
 
     options = (typeof options === 'string')
-      ? {replacement: options}
+      ? { replacement: options }
       : options || {}
 
     var slug = string.split('')

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "types": "index.d.ts",
   "scripts": {
-    "lint": "eslint index.js test.js && echo Lint Passed",
+    "lint": "eslint index.js test.js build.js && echo Lint Passed",
     "test": "npm run lint && npm run test:ci && echo Tests Passed",
     "test:ci": "mocha",
     "test:cov": "istanbul cover _mocha"

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.1",
-    "eslint": "^4.19.1",
-    "eslint-config-standard": "^11.0.0",
+    "eslint": "^5.10.0",
+    "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.7.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.1.1"
   },

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable node/no-deprecated-api */
 var t = require('assert')
 
 describe('slugify', function () {
@@ -58,18 +58,18 @@ describe('slugify', function () {
   })
 
   it('options.replacement', function () {
-    t.equal(slugify('foo bar baz', {replacement: '_'}), 'foo_bar_baz')
+    t.equal(slugify('foo bar baz', { replacement: '_' }), 'foo_bar_baz')
   })
 
   it('options.remove', function () {
     t.equal(slugify(
       'foo *+~.() bar \'"!:@ baz',
-      {remove: /[$*_+~.()'"!\-:@]/g}
+      { remove: /[$*_+~.()'"!\-:@]/g }
     ), 'foo-bar-baz')
   })
 
   it('options.lower', function () {
-    t.equal(slugify('Foo bAr baZ', {lower: true}), 'foo-bar-baz')
+    t.equal(slugify('Foo bAr baZ', { lower: true }), 'foo-bar-baz')
   })
 
   it('replace latin chars', function () {
@@ -215,7 +215,7 @@ describe('slugify', function () {
   })
 
   it('replace custom characters', function () {
-    slugify.extend({'☢': 'radioactive'})
+    slugify.extend({ '☢': 'radioactive' })
     t.equal(slugify('unicode ♥ is ☢'), 'unicode-love-is-radioactive')
 
     delete require.cache[require.resolve('./')]


### PR DESCRIPTION
The most significant change is that tests now use strict assertions, legacy assertions were deprecated with Node.js 10.