### PR TITLE
Add CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 
 [![npm-version]][npm] [![travis-ci]][travis] [![coveralls-status]][coveralls]
 
+- Vanilla ES5 JavaScript
+- No dependencies
+- Coerces foreign symbols to their english equivalent (check out the `charMap` in [index.js][index] for more details)
+- Works in the browser (window.slugify), AMD/CommonJS-flavored module loaders and command line
+
+## Usage
+
+### Node
+
 ```js
 var slugify = require('slugify')
 
@@ -12,10 +21,24 @@ slugify('some string') // some-string
 slugify('some string', '_')  // some_string
 ```
 
-- Vanilla ES5 JavaScript
-- No dependencies
-- Coerces foreign symbols to their english equivalent (check out the `charMap` in [index.js][index] for more details)
-- Works in the browser (window.slugify) and AMD/CommonJS-flavored module loaders
+### Browser
+
+```html
+<script src="https://unpkg.com/slugify@1.3.4/index.js"></script>
+<script>
+  var string = 'some string'
+  console.log(slugify(string));
+</script>
+```
+
+### CLI
+
+```bash
+echo 'some string' | slugify
+> some-string
+slugify -s 'some string'
+> some-string
+```
 
 ## Options
 
@@ -28,6 +51,15 @@ slugify('some string', {
 ```
 
 For example, to remove `*+~.()'"!:@` from the result slug, you can use `slugify('..', {remove: /[*+~.()'"!:@]/g})`.
+
+Options are also available in CLI mode:
+
+```bash
+slugify -s 'Some String' -l
+> some-string
+slugify -s 'some string' -r '_'
+> some_string
+```
 
 ## Extend
 

--- a/bin/slugify
+++ b/bin/slugify
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+var slugify = require('../')
+
+function help () {
+  console.log('Usage: slugify [options] -s \'string\'\n' +
+'       echo \'string\' | slugify [options]\n' +
+'\n' +
+'Options:\n' +
+'  -s, --string            the string to slugify\n' +
+'  -r, --replacement char  defines words separator\n' +
+'  -R, --remove regex      remove characters\n' +
+'  -l, --lower             result in lower case\n' +
+'  -h, --help              display this help and exit')
+}
+
+function main (argv, callback) {
+  var arg
+  var string
+  var options = []
+
+  function getArg () {
+    var arg = argv.shift()
+
+    if (arg.indexOf('--') === 0) {
+      // e.g. --opt
+      arg = arg.split('=')
+      if (arg.length > 1) {
+        // e.g. --opt=val
+        argv.unshift(arg.slice(1).join('='))
+      }
+      arg = arg[0]
+    }
+    else if (arg[0] === '-') {
+      if (arg.length > 2) {
+        // e.g. -abc
+        argv = arg.substring(1).split('').map(function (ch) {
+          return '-' + ch
+        }).concat(argv)
+        arg = argv.shift()
+      }
+    }
+
+    return arg
+  }
+
+  // Remove `node` and `slugify` CLI arguments
+  argv.shift()
+  argv.shift()
+
+  while (argv.length) {
+    arg = getArg()
+    switch (arg) {
+      case '-s':
+      case '--string':
+        string = argv.shift()
+        break
+      case '-h':
+      case '--help':
+        return help()
+      case '-r':
+      case '--replacement':
+        options['replacement'] = argv.shift()
+        break
+      case '-R':
+      case '--remove':
+        options['remove'] = argv.shift()
+        break
+      case '-l':
+      case '--lower':
+        options['lower'] = true
+        break
+      default:
+        console.log(arg)
+        console.log('usage: slugify -s \'Hola món\'')
+        console.log('slugify -h for more options.')
+        break
+    }
+  }
+
+  if (string) {
+    process.stdout.write(slugify(string, options) + '\n')
+    return callback()
+  }
+  else { // if -s option is not given, process stdin
+    var stdin = process.stdin
+    var buff = ''
+
+    stdin.setEncoding('utf8')
+
+    stdin.on('data', function (data) {
+      buff += data
+    })
+
+    stdin.on('error', function (err) {
+      return callback(err)
+    })
+
+    stdin.on('end', function () {
+      process.stdout.write(slugify(buff, options) + '\n')
+      return callback()
+    })
+
+    try {
+      stdin.resume()
+    }
+    catch (err) {
+      callback(err)
+    }
+  }
+
+}
+
+/**
+ * Expose / Entry Point
+ */
+
+if (!module.parent) {
+  process.title = 'slugify'
+  main(process.argv.slice(), function (err, code) {
+    if (err) {
+      throw err
+    }
+    return process.exit(code || 0)
+  })
+}
+else {
+  module.exports = main
+}

--- a/package.json
+++ b/package.json
@@ -27,11 +27,16 @@
     "mocha": "^5.1.1"
   },
   "main": "./index.js",
+  "preferGlobal": true,
+  "bin": {
+    "mycliapp": "./bin/slugify"
+  },
   "files": [
     "LICENSE",
     "README.md",
     "index.d.ts",
-    "index.js"
+    "index.js",
+    "bin/"
   ],
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Add ability to execute slugify through command-line.

## Usage

**Typical**

```bash
$slugify -s 'some string'
some-string
```

**Via stdin**

```bash
$echo 'some string' | slugify
some-string
```

**With options**

```bash
$slugify -s 'Some String' -l
some-string
$slugify --string 'Some String' --lower --replace '_'
some_string
```

**Help**

```bash
$slugify -h                    
Usage: slugify [options] -s 'string'
       echo 'string' | slugify [options]

Options:
  -s, --string            the string to slugify
  -r, --replacement char  defines words separator
  -R, --remove regex      remove characters
  -l, --lower             result in lower case
  -h, --help              display this help and exit
```