### PR TITLE
Separate tests from the build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,33 +1,15 @@
-
 var fs = require('fs')
-var charmap = require('./charmap')
 
-
-exports.sort = function () {
+function sortCharmap () {
+  var charmap = JSON.parse(fs.readFileSync('charmap.json', 'utf8'))
   var sorted = charmap.sort(function (a, b) {
     return a.key > b.key ? 1 : a.key < b.key ? -1 : 0
   })
   fs.writeFileSync('charmap.json', JSON.stringify(sorted, null, 2), 'utf8')
 }
 
-exports.duplicates = function () {
-  var cache = {}
-  var duplicates = []
-  charmap.forEach(function (pair) {
-    if (!cache[pair.key]) {
-      cache[pair.key] = pair
-    }
-    else {
-      duplicates.push(pair)
-    }
-  })
-  return {
-    cache: cache,
-    duplicates: duplicates
-  }
-}
-
-exports.replace = function () {
+function replaceCharmap () {
+  var charmap = JSON.parse(fs.readFileSync('charmap.json', 'utf8'))
   var obj = charmap.reduce(function (obj, pair) {
     obj[pair.key] = pair.value
     return obj
@@ -44,3 +26,6 @@ exports.replace = function () {
 
   fs.writeFileSync('index.js', source, 'utf8')
 }
+
+sortCharmap()
+replaceCharmap()

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
   ],
   "types": "index.d.ts",
   "scripts": {
+    "build": "node build.js && echo Build completed",
     "lint": "eslint index.js test.js build.js && echo Lint Passed",
     "test": "npm run lint && npm run test:ci && echo Tests Passed",
-    "test:ci": "mocha",
-    "test:cov": "istanbul cover _mocha"
+    "test:ci": "npm run build && mocha",
+    "test:cov": "npm run build && istanbul cover _mocha"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test.js
+++ b/test.js
@@ -1,15 +1,8 @@
 /* eslint-disable node/no-deprecated-api */
 var t = require('assert')
+var slugify = require('./')
 
 describe('slugify', function () {
-  var build = require('./build')
-  var slugify
-
-  before(function () {
-    build.replace()
-    slugify = require('./')
-  })
-
   it('throws', function () {
     try {
       slugify(undefined)
@@ -20,11 +13,27 @@ describe('slugify', function () {
   })
 
   it('duplicates characters are not allowed', function () {
-    var result = build.duplicates()
+    var charmap = require('./charmap.json')
+
+    function getDuplicates (charmap) {
+      var cache = {}
+      var duplicates = []
+      charmap.forEach(function (pair) {
+        if (!cache[pair.key]) {
+          cache[pair.key] = pair
+        }
+        else {
+          duplicates.push(pair)
+        }
+      })
+      return duplicates
+    }
+
+    var result = getDuplicates(charmap)
     t.equal(
-      result.duplicates.length,
+      result.length,
       0,
-      'duplicates: ' + result.duplicates
+      'duplicates: ' + result
         .map(function (pair) {
           return pair.key
         })
@@ -276,9 +285,5 @@ describe('slugify', function () {
         'a-b-g-d-e-v-z-t-i-k-l-m-n-o-p-zh-r-s-t-u-f-k-gh-q-sh-ch-ts-dz-ts-ch-kh-j-h'
       )
     })
-  })
-
-  after(function () {
-    build.sort()
   })
 })


### PR DESCRIPTION
This is taking a safe refactoring from #43 that is, IMHO, valuable without the rest.

It separated the build step from the test to make it easier to follow what's going on in each part.