### PR TITLE
Add remover option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ slugify('some string', '_')  // some_string
 slugify('some string', {
   replacement: '-',    // replace spaces with replacement
   remove: null,        // regex to remove characters
+  remover: '',         // replace remove regex match with remover
   lower: true          // result in lower case
 })
 ```

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
       .reduce(function (result, ch) {
         return result + (charMap[ch] || ch)
           // allowed
-          .replace(options.remove || /[^\w\s$*_+~.()'"!\-:@]/g, '')
+          .replace(options.remove || /[^\w\s$*_+~.()'"!\-:@]/g, options.remover || '')
       }, '')
       // trim leading/trailing spaces
       .trim()


### PR DESCRIPTION
This PR adds a new option that is useful when you want to replace special characters rather than removing them. As the regex option name is called `remove` I thought that `remover` could be a good name but I'm not sure (no breaking changes).

Example:
```javascript
slugify('Çumra.fdf', {
    replacement: '-',
    remover: ' ',
    lower: true
});

// output: cumra-fdf
```

Any feedback would be appreciated, thanks in advance.