### PR TITLE
Implemented strict mode #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ slugify('some string', '_')  // some_string
 
 ```js
 slugify('some string', {
-  replacement: '-',    // replace spaces with replacement
-  remove: null,        // regex to remove characters
-  lower: true,         // result in lower case
+  replacement: '-',  // set replacement character, defaults to `-`
+  remove: undefined, // remove characters that match regex, defaults to `undefined`
+  lower: false,      // convert to lower case, defaults to `false`
+  strict: false,     // strip special characters except replacement, defaults to `false`
 })
 ```
 

--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -13,6 +13,7 @@ declare function slugify(
         replacement?: string;
         remove?: RegExp;
         lower?: boolean;
+        strict?: boolean;
       }
     | string,
 

--- a/slugify.js
+++ b/slugify.js
@@ -26,6 +26,8 @@
 
     var locale = locales[options.locale] || {}
 
+    var replacement = options.replacement || '-'
+
     var slug = string.split('')
       .reduce(function (result, ch) {
         return result + (locale[ch] || charMap[ch] || ch)
@@ -34,10 +36,19 @@
       }, '')
       // trim leading/trailing spaces
       .trim()
-      // convert spaces
-      .replace(/[-\s]+/g, options.replacement || '-')
+      // convert spaces to replacement characters
+      .replace(new RegExp('[\\s' + replacement + ']+', 'g'), replacement)
 
-    return options.lower ? slug.toLowerCase() : slug
+    if (options.lower) {
+      slug = slug.toLowerCase()
+    }
+
+    if (options.strict) {
+      slug = slug
+        .replace(new RegExp('[^a-zA-Z0-9' + replacement + ']', 'g'), '')
+    }
+
+    return slug
   }
 
   replace.extend = function (customMap) {

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -52,6 +52,17 @@ describe('slugify', () => {
     t.equal(slugify('Foo bAr baZ', {lower: true}), 'foo-bar-baz')
   })
 
+  it('options.strict', () => {
+    t.equal(slugify('foo_bar. -baz!', {strict: true}), 'foobar-baz')
+  })
+
+  it('options.replacement and options.strict', () => {
+    t.equal(slugify('foo_bar-baz!', {
+      replacement: '_',
+      strict: true
+    }), 'foo_barbaz')
+  })
+
   it('replace latin chars', () => {
     var charMap = {
       'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'A', 'Å': 'A', 'Æ': 'AE',


### PR DESCRIPTION
This PR addresses a bias towards `-` and implements a new `strict` option that, when set to `true`, strips special characters except replacement.