### PR TITLE
Add example for strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,27 @@ slugify('some string', {
 })
 ```
 
-For example, to remove `*+~.()'"!:@` from the result slug, you can use `slugify('..', {remove: /[*+~.()'"!:@]/g})`.
+### Examples
+
+#### Remove special characters
+
+Remove `$*_+~.()'"!\-:@`.
+
+```js
+let slug = 'foo *+~.() bar \'"!:@ baz'
+slugify(slug, {remove: /[$*_+~.()'"!\-:@]/g})
+// foo-bar-baz
+```
+
+#### Strict mode
+
+Remove any character that doesn't match `[a-zA-Z0-9-]`, except the replacement.
+
+```js
+let slug = 'foo_bar. -baz!'
+slugify(slug, {strict: true})
+// foobar-baz
+```
 
 ## Extend
 


### PR DESCRIPTION
1.4.0 added a strict mode which offers a more reliable way to remove special characters from a slug.

See https://github.com/simov/slugify/pull/74.

Document this functionality by adding an example. The current README suggests `remove` as a way of removing special characters, but `strict` may be a better option for some, so an example is added for this option.

Also updated the `remove` example for consistency with the tests.