### PR TITLE
Ensure duplicate replacement characters are removed in strict mode

### DIFF
--- a/slugify.js
+++ b/slugify.js
@@ -37,9 +37,6 @@
       .replace(options.remove || /[^\w\s$*_+~.()'"!\-:@]+/g, '')
       // trim leading/trailing spaces
       .trim()
-      // convert spaces to replacement character
-      // also remove duplicates of the replacement character
-      .replace(new RegExp('[\\s' + replacement + ']+', 'g'), replacement)
 
     if (options.lower) {
       slug = slug.toLowerCase()
@@ -50,6 +47,11 @@
       slug = slug
         .replace(new RegExp('[^a-zA-Z0-9' + replacement + ']', 'g'), '')
     }
+
+    slug = slug
+      // convert spaces to replacement character
+      // also remove duplicates of the replacement character
+      .replace(new RegExp('[\\s' + replacement + ']+', 'g'), replacement)
 
     return slug
   }

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -54,11 +54,11 @@ describe('slugify', () => {
   })
 
   it('options.strict', () => {
-    t.equal(slugify('foo_bar. -baz!', {strict: true}), 'foobar-baz')
+    t.equal(slugify('foo_bar. -@-baz!', {strict: true}), 'foobar-baz')
   })
 
   it('options.replacement and options.strict', () => {
-    t.equal(slugify('foo_bar-baz!', {
+    t.equal(slugify('foo_@_bar-baz!', {
       replacement: '_',
       strict: true
     }), 'foo_barbaz')


### PR DESCRIPTION
Change the order of strict mode character replacement to ensure duplicate replacement characters are removed as expected.

Appropriate tests updated.