### PR TITLE
Added url option - removed all non url complient characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ slugify('some string', {
   lower: false,      // convert to lower case, defaults to `false`
   strict: false,     // strip special characters except replacement, defaults to `false`
   locale: 'vi',      // language code of the locale to use
-  url: false,        // strips all non English alphabet characters
+  url: false,        // strips all non English characters (doesn't strip numbers), defaults to `false`
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ slugify('some string', {
   remove: undefined, // remove characters that match regex, defaults to `undefined`
   lower: false,      // convert to lower case, defaults to `false`
   strict: false,     // strip special characters except replacement, defaults to `false`
-  locale: 'vi'       // language code of the locale to use
+  locale: 'vi',      // language code of the locale to use
+  url: false,        // strips all non english alphabet characters
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ slugify('some string', {
   lower: false,      // convert to lower case, defaults to `false`
   strict: false,     // strip special characters except replacement, defaults to `false`
   locale: 'vi',      // language code of the locale to use
-  url: false,        // strips all non english alphabet characters
+  url: false,        // strips all non English alphabet characters
 })
 ```
 

--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -15,6 +15,7 @@ declare function slugify(
         lower?: boolean;
         strict?: boolean;
         locale?: string;
+        url?: boolean;
       }
     | string,
 

--- a/slugify.js
+++ b/slugify.js
@@ -53,6 +53,10 @@
         .replace(new RegExp('[\\s' + replacement + ']+', 'g'), replacement)
     }
 
+    if (options.url) {
+      slug = slug.replace(new RegExp('(?![a-zA-Z0-9]).', 'g'), '')
+    }
+
     return slug
   }
 

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -83,6 +83,11 @@ describe('slugify', () => {
     }), 'foo_barbaz')
   })
 
+  it('options.url', () => {
+    t.equal(slugify('foo_bar. -@-baz!', {url: true}), 'foobarbaz')
+    t.equal(slugify('aaa@!#!bbb. -@-ccc!', {url: true}), 'aaabbbccc')
+  })
+
   it('replace latin chars', () => {
     var charMap = {
       'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'A', 'Å': 'A', 'Æ': 'AE',


### PR DESCRIPTION
closes #50 

Currently the option removes all non English alphabet characters (besides numbers).