### PR TITLE
Indicate that ES2015 is required & use Object.assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ slugify('some string') // some-string
 slugify('some string', '_')  // some_string
 ```
 
-- Vanilla ES5 JavaScript
+- Vanilla ES2015 JavaScript
+    - If you need to use Slugify with older browsers, consider using [version 1.4.7](https://github.com/simov/slugify/releases/tag/v1.4.7)
 - No dependencies
 - Coerces foreign symbols to their English equivalent (check out the [charMap][charmap] for more details)
 - Works in the browser (window.slugify) and AMD/CommonJS-flavored module loaders

--- a/slugify.js
+++ b/slugify.js
@@ -57,9 +57,7 @@
   }
 
   replace.extend = function (customMap) {
-    for (var key in customMap) {
-      charMap[key] = customMap[key]
-    }
+    Object.assign(charMap, customMap)
   }
 
   return replace


### PR DESCRIPTION
Bases on the earlier discussion (https://github.com/simov/slugify/commit/2df63f965aaf63844a51d3c3fab7704d83a31877#r48602916) I'd like to propose two changes:

- Indicate in the Readme that ES2015 is required
- Since it's required, it can be used to simplify the code for the extend() function. Shaving of some more bytes of the size of this module :)