### PR TITLE
Support multiple code unit charaters

### DIFF
--- a/slugify.js
+++ b/slugify.js
@@ -28,7 +28,7 @@
 
     var replacement = options.replacement === undefined ? '-' : options.replacement
 
-    var slug = string.normalize().split('')
+    var slug = Array.from(string.normalize())
       // replace characters based on charMap
       .reduce(function (result, ch) {
         return result + (locale[ch] || charMap[ch] || ch)

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -249,6 +249,16 @@ describe('slugify', () => {
     t.equal(slugify('unicode ♥ is ☢'), 'unicode-love-is')
   })
 
+  it('replace characters made up of multiple code units', () => {
+    slugify.extend({'🚣': 'person-rowing-boat'})
+    t.equal(slugify('she is a 🚣'), 'she-is-a-person-rowing-boat')
+
+    delete require.cache[require.resolve('../')]
+    slugify = require('../')
+
+    t.equal(slugify('she is a 🚣'), 'she-is-a')
+  })
+
   it('normalize', () => {
     var slug = decodeURIComponent('a%CC%8Aa%CC%88o%CC%88-123') // åäö-123
     t.equal(slugify(slug, {remove: /[*+~.()'"!:@]/g}), 'aao-123')


### PR DESCRIPTION
Relates to #72

This is not not full emoji support but it makes it possible to replace characters that are made up multiple code units but only one code point.
Newer emojis are made up of multiple code points, joined by zero width spaces, and would require proper grapheme cluster support. I think that's out of scope for slugify.

The problem might be that this will be confusing for users as _some_ emojis will work but not _all_ emojis.