### PR TITLE
Add option 'trim' to remove separator at start and at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ slugify('some string', {
   lower: false,      // convert to lower case, defaults to `false`
   strict: false,     // strip special characters except replacement, defaults to `false`
   locale: 'vi'       // language code of the locale to use
+  trim: false        // remove separator at start and at the end, defaults to `false`
 })
 ```
 

--- a/slugify.js
+++ b/slugify.js
@@ -54,8 +54,14 @@
     }
 
     if (options.trim) {
+      //escape special characters
+      if('.*+-?^${}()|[]@\\'.includes(replacement)) {
+        replacement = '\\' + replacement
+      }
       slug = slug
+        // remove separator at start
         .replace(new RegExp('^' + replacement + '+'), '')
+        // remove separator at the end
         .replace(new RegExp(replacement + '+$'), '')
     }
 

--- a/slugify.js
+++ b/slugify.js
@@ -53,6 +53,12 @@
         .replace(new RegExp('[\\s' + replacement + ']+', 'g'), replacement)
     }
 
+    if (options.trim) {
+      slug = slug
+        .replace(new RegExp('^' + replacement + '+'), '')
+        .replace(new RegExp(replacement + '+$'), '')
+    }
+
     return slug
   }
 

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -76,6 +76,15 @@ describe('slugify', () => {
     t.equal(slugify('foo @ bar', {strict: true}), 'foo-bar')
   })
 
+  it('options.trim - remove separator at start and at the end', () => {
+    t.equal(slugify('-foo bar', {trim: true}), 'foo-bar')                     // at start
+    t.equal(slugify('foo bar-', {trim: true}), 'foo-bar')                     // at the end
+    t.equal(slugify('-foo bar-', {trim: true}), 'foo-bar')                    // both
+    t.equal(slugify('---foo bar', {trim: true}), 'foo-bar')                   // duplicate at start
+    t.equal(slugify('--foo bar---', {trim: true}), 'foo-bar')                 // duplicate both
+    t.equal(slugify('_foo bar__', {replacement: '_', trim: true}), 'foo_bar') // another separator
+  })
+
   it('options.replacement and options.strict', () => {
     t.equal(slugify('foo_@_bar-baz!', {
       replacement: '_',

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -83,6 +83,8 @@ describe('slugify', () => {
     t.equal(slugify('---foo bar', {trim: true}), 'foo-bar')                   // duplicate at start
     t.equal(slugify('--foo bar---', {trim: true}), 'foo-bar')                 // duplicate both
     t.equal(slugify('_foo bar__', {replacement: '_', trim: true}), 'foo_bar') // another separator
+    t.equal(slugify('*foo bar**', {replacement: '*', trim: true}), 'foo*bar') // special character
+    t.equal(slugify('.foo bar..', {replacement: '.', trim: true}), 'foo.bar') // special character
   })
 
   it('options.replacement and options.strict', () => {


### PR DESCRIPTION
Sometimes programmers may prefer that the separator does not appear at the beginning and end of a friendly url, like
```javascript
slugify('-This is my first article') // -This-is-my-first-article
```
The above is the default behavior. I have added the `trim `option (defaults to `false`) to allow to remove this separator (or another defined in `replacement`) at the beginning and at the end of the string.
```javascript
slugify('-This is my first article without initial dash --', { trim: true }) // This-is-my-first-article-without-initial-dash
```
