### PR TITLE
fix: remove replacement char from start and end in strict mode

### DIFF
--- a/slugify.js
+++ b/slugify.js
@@ -34,23 +34,20 @@
         return result + (locale[ch] || charMap[ch] ||  (ch === replacement ? ' ' : ch))
           // remove not allowed characters
           .replace(options.remove || /[^\w\s$*_+~.()'"!\-:@]+/g, '')
-      }, '')
-      // trim leading/trailing spaces
-      .trim()
-      // convert spaces to replacement character
-      // also remove duplicates of the replacement character
-      .replace(/\s+/g, replacement)
+      }, '');
+
+    if (options.strict) {
+      slug = slug.replace(/[^A-Za-z0-9\s]/g, '');
+    }
+
+    // Remove leading/trailing spaces, then replace all other spaces with
+    // replacement character, treating multiple consecutive spaces as a single
+    // space.
+    slug = slug.trim()
+      .replace(/\s+/g, replacement);
 
     if (options.lower) {
       slug = slug.toLowerCase()
-    }
-
-    if (options.strict) {
-      // remove anything besides letters, numbers, and the replacement char
-      slug = slug
-        .replace(new RegExp('[^a-zA-Z0-9' + replacement + ']', 'g'), '')
-        // remove duplicates of the replacement character
-        .replace(new RegExp('[\\s' + replacement + ']+', 'g'), replacement)
     }
 
     return slug

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -257,4 +257,8 @@ describe('slugify', () => {
   it('replaces leading and trailing replacement chars', () => {
     t.equal(slugify('-Come on, fhqwhgads-'), 'Come-on-fhqwhgads')
   })
+
+  it('replaces leading and trailing replacement chars in strict mode', () => {
+    t.equal(slugify('! Come on, fhqwhgads !', { strict: true }), 'Come-on-fhqwhgads')
+  })
 })


### PR DESCRIPTION
In addition to fixing the bug, this also removes dynamically generated
regular expresions which could result in unexpected behavior when the
replacement character is a special character in regulard expressions,
such as `.`.

Refs: https://github.com/simov/slugify/issues/112#issuecomment-836365587