### PR TITLE
fix: remove() should work with multichar strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ slugify('some string', {
 
 For example, to remove `*+~.()'"!:@` from the result slug, you can use `slugify('..', {remove: /[*+~.()'"!:@]/g})`.
 
+The `remove` option uses `String.prototype.replace()`. This means that it will
+only remove the first match if it is a string or a regular expression without
+the global (`g`) flag. To remove all matches, supply a regular expression with
+the global (`g`) flag.
+
 ## Locales
 
 The main `charmap.json` file contains all known characters and their transliteration. All new characters should be added there first. In case you stumble upon a character already set in `charmap.json`, but not transliterated correctly according to your language, then you have to add those characters in `locales.json` to override the already existing transliteration in `charmap.json`, but for your locale only.

--- a/slugify.js
+++ b/slugify.js
@@ -38,9 +38,9 @@
           appendChar = ' ';
         }
         return result + appendChar
-          // remove not allowed characters
-          .replace(options.remove || /[^\w\s$*_+~.()'"!\-:@]+/g, '')
-      }, '');
+      }, '')
+      // remove not allowed characters
+      .replace(options.remove || /[^\w\s$*_+~.()'"!\-:@]+/g, '');
 
     if (options.strict) {
       slug = slug.replace(/[^A-Za-z0-9\s]/g, '');

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -55,13 +55,18 @@ describe('slugify', () => {
       'foo *+~.() bar \'"!:@ baz',
       {remove: /[$*_+~.()'"!\-:@]/g}
     ), 'foo-bar-baz')
+
+    t.equal(slugify(
+      'AFdAFd',
+      { remove: /AF/g }
+    ), 'dd')
   })
 
   it('options.remove regex without g flag', () => {
     t.equal(slugify(
       'foo bar, bar foo, foo bar',
       {remove: /[^a-zA-Z0-9 -]/}
-    ), 'foo-bar-bar-foo-foo-bar')
+    ), 'foo-bar-bar-foo,-foo-bar')
   })
 
   it('options.lower', () => {


### PR DESCRIPTION
Fixes: https://github.com/simov/slugify/issues/164

BREAKING CHANGE: remove() behavior now aligns with
Stirng.prototype.replace(). To remove more than the first
instance/match, use a regular expression with the global (g) flag.