### PR TITLE
fix: correct CommonJS export for "module": "node16" + ESM

### DIFF
--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -4,6 +4,8 @@ declare module slugify {
   }
 
   export function extend (args: ExtendArgs): void;
+  const _default: typeof slugify;
+  export { _default as default };
 }
 
 declare function slugify(
@@ -22,3 +24,4 @@ declare function slugify(
 ): string;
 
 export = slugify;
+export as namespace slugify;

--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -21,4 +21,4 @@ declare function slugify(
 
 ): string;
 
-export default slugify;
+export = slugify;


### PR DESCRIPTION
Hi there 👋 First of all, thanks for `slugify`, it's very useful!

The ESM-style export (`export default slugify`) causes an error when using the `"module": "node16"` option in `tsconfig.json` and `"type": "module"` in `package.json`:

```bash
$ yarn tsc
index.ts:3:1 - error TS2349: This expression is not callable.
  Type 'typeof import("/home/projects/node-wshdsj/node_modules/slugify/slugify")' has no call signatures.

3 slugify('');
  ~~~~~~~


Found 1 error in index.ts:3

error Command failed with exit code 2.
```

Demo on StackBlitz - run `yarn tsc` in the Terminal at the bottom to reproduce:

https://stackblitz.com/edit/node-wshdsj?file=tsconfig.json,package.json,index.ts&file=tsconfig.json,index.ts

![Screenshot 2023-01-29 at 18 04 37](https://user-images.githubusercontent.com/1935696/215343330-afa8427c-3765-408f-83ca-97babcfb0c5b.png)

## Background

The change to ESM-style export in https://github.com/simov/slugify/pull/19 seemed like the right solution at the time, because bundlers such as webpack + `ts-loader` did not understand the CommonJS syntax (`export = slugify`).

However, module systems have evolved since then and now the `export default` fails when `"module": "node16"` is configured in `tsconfig.json` inside of a project which is an ES Module (`"type": "module"` in `package.json`).

Since `slugify` is a CommonJS module, it seems like using a CommonJS-style export is indeed the right choice for this package.

See more information about the problem of misconfigured declaration files in packages here:

- https://github.com/microsoft/TypeScript/issues/49160#issuecomment-1137482639
- https://github.com/microsoft/TypeScript/issues/49189#issuecomment-1137756847