### PR TITLE
Add `preserve` option to allow preserving additional characters in strict mode

### DIFF
--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -16,6 +16,7 @@ declare function slugify(
         strict?: boolean;
         locale?: string;
         trim?: boolean;
+        preserve?: string[];
       }
     | string,
 

--- a/slugify.js
+++ b/slugify.js
@@ -43,7 +43,9 @@
       }, '');
 
     if (options.strict) {
-      slug = slug.replace(/[^A-Za-z0-9\s]/g, '');
+      const preserveCharacters = options.preserve ? `\\${options.preserve.join('\\')}` : '';
+      const regex = new RegExp(`[^A-Za-z0-9${preserveCharacters}\\s]`, 'g');
+      slug = slug.replace(regex, '');
     }
 
     if (trim) {

--- a/test/slugify.js
+++ b/test/slugify.js
@@ -76,6 +76,14 @@ describe('slugify', () => {
     t.equal(slugify('foo @ bar', {strict: true}), 'foo-bar')
   })
 
+  it('options.strict, options.preserve and options.replacement', () => {
+    t.equal(slugify('!foo.bar_baz@#~', {
+      replacement: '_',
+      strict: true,
+      preserve: ['.']
+    }), 'foo.bar_baz')
+  })
+
   it('options.replacement and options.strict', () => {
     t.equal(slugify('foo_@_bar-baz!', {
       replacement: '_',


### PR DESCRIPTION
This allows `preserve` option, which will preserve specified characters when using strict mode.
It allows for different structures, like `test_property` and `test.property` being valid. Another example is having more complex paths: `path.to.property_name`.

Modifying this to fit non-strict mode could probably be used to fix https://github.com/simov/slugify/pull/131 as well.

Does not affect current implementation in any way.