### PR TITLE
Run CI in Node.js 20

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node 20 has been LTS version for quite some time. Ensure slugify keeps working with it.