### PR TITLE
Change TS typings to expose slugify.extend

### DIFF
--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -1,24 +1,19 @@
-declare module slugify {
-  type ExtendArgs = {
-    [key: string]: any;
-  }
+declare const slugify: {
+  (
+    string: string,
+    options?:
+      | {
+          replacement?: string;
+          remove?: RegExp;
+          lower?: boolean;
+          strict?: boolean;
+          locale?: string;
+          trim?: boolean;
+        }
+      | string,
 
-  export function extend (args: ExtendArgs): void;
-}
-
-declare function slugify(
-  string: string,
-  options?:
-    | {
-        replacement?: string;
-        remove?: RegExp;
-        lower?: boolean;
-        strict?: boolean;
-        locale?: string;
-        trim?: boolean;
-      }
-    | string,
-
-): string;
+  ): string;
+  extend: (args: Record<string, any>) => void;
+};
 
 export default slugify;


### PR DESCRIPTION
The current typings make `slugify.extend` inaccessible since the default export is just the function, and not the module.

This version exports a value which is both callable (the function) and has an `extend` property.