### PR TITLE
fix: update slugify.d.ts to use namespace instead of module (TS1540)

### DIFF
--- a/slugify.d.ts
+++ b/slugify.d.ts
@@ -1,4 +1,4 @@
-declare module slugify {
+declare namespace slugify {
   type ExtendArgs = {
     [key: string]: any;
   }


### PR DESCRIPTION
Summary:

This PR fixes a TypeScript compilation error (TS1540) where the compiler complains about using the module keyword for a namespace declaration in slugify.d.ts.

Error Details:

```
error TS1540: A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead.
```

Changes:
- Changed declare module slugify to declare namespace slugify in slugify.d.ts

This change ensures compatibility with modern TypeScript versions (5.x+) while maintaining the existing type definitions.